### PR TITLE
Configure backend to load MySQL credentials from dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=Frozzyt123
+DB_NAME=toko_online

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,3 +1,6 @@
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
+
 const express = require('express');
 const app = express();
 const db = require('./db');

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,10 +1,12 @@
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
 const mysql = require('mysql2');
 
 const db = mysql.createConnection({
-  host: 'localhost',
-  user: 'root',
-  password: 'Frozzyt123',
-  database: 'toko_online'
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME
 });
 
 db.connect(err => {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^10.0.0",
         "express": "^5.1.0",
         "node": "^22.19.0"
       }
@@ -103,6 +104,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cookie": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "dotenv": "^10.0.0",
     "express": "^5.1.0",
     "node": "^22.19.0"
   }


### PR DESCRIPTION
## Summary
- add a repository-level `.env` file containing the MySQL connection variables
- initialize dotenv in the backend entrypoints and read the MySQL connection options from `process.env`
- declare the dotenv dependency for the backend package

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c90a20dbe48328b35a5c341640ce3e