### PR TITLE
Switch backend to Google Sheets

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^10.0.0",
         "express": "^5.1.0",
+        "googleapis": "^140.0.0",
         "node": "^22.19.0"
       }
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "dotenv": "^10.0.0",
     "express": "^5.1.0",
+    "googleapis": "^140.0.0",
     "node": "^22.19.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace the MySQL-backed db module with a Google Sheets client that uses service-account credentials from environment variables
- update the /users endpoints to append new rows and return sheet rows as user objects while skipping an optional header row
- add the googleapis dependency so the backend can work with the Google Sheets API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c90db50c6883288929df82b21aa401